### PR TITLE
Add request URI index.html path appending to viewer request func

### DIFF
--- a/src/handlers/check-auth.ts
+++ b/src/handlers/check-auth.ts
@@ -10,6 +10,12 @@ import { createNonceHmac, generateNonce } from "./util/nonce"
 export const handler = createRequestHandler(async (config, event) => {
   const request = event.Records[0].cf.request
   const domainName = request.headers["host"][0].value
+  if (request.uri.endsWith("/")) {
+    request.uri += "index.html"
+  }
+  if (!request.uri.includes(".")) {
+    request.uri += "/index.html"
+  }
   const requestedUri = `${request.uri}${
     request.querystring ? "?" + request.querystring : ""
   }`


### PR DESCRIPTION
Before this change, the `check-auth` viewer-request event function handler only handled.. auth checking.

After this change, it is tweaked for SSG next.js builds. It simply appends "index.html" accordingly to the requested URI so that CloudFront can find the appropriate assets at the right path.

The reason for forking repo+tweaking existing function is because CloudFront allows for only one edge function association (check-auth handler) per cache behavior event type (viewer-request) per origin (s3 origin with Nextjs bundle). To maximize cache hits, it is optimal to have request URI rewrites done within viewer-request event.